### PR TITLE
Add tests for AnyCompositeCheckpointMatcher

### DIFF
--- a/common/src/main/java/io/polyakov/tracy/matcher/AllCompositeCheckpointMatcher.kt
+++ b/common/src/main/java/io/polyakov/tracy/matcher/AllCompositeCheckpointMatcher.kt
@@ -6,6 +6,12 @@ class AllCompositeCheckpointMatcher(
     private vararg val matchers: CheckpointMatcher
 ) : CheckpointMatcher {
 
+    init {
+        require(matchers.isNotEmpty()) {
+            "No matchers passed for AllCompositeCheckpointMatcher. At least one matcher is required."
+        }
+    }
+
     override fun matches(checkpoint: Checkpoint): Boolean {
         return matchers.all { it.matches(checkpoint) }
     }

--- a/common/src/main/java/io/polyakov/tracy/matcher/AnyCompositeCheckpointMatcher.kt
+++ b/common/src/main/java/io/polyakov/tracy/matcher/AnyCompositeCheckpointMatcher.kt
@@ -6,6 +6,12 @@ class AnyCompositeCheckpointMatcher(
     private vararg val matchers: CheckpointMatcher
 ) : CheckpointMatcher {
 
+    init {
+        require(matchers.isNotEmpty()) {
+            "No matchers passed for AnyCompositeCheckpointMatcher. At least one matcher is required."
+        }
+    }
+
     override fun matches(checkpoint: Checkpoint): Boolean {
         return matchers.any { it.matches(checkpoint) }
     }

--- a/common/src/test/kotlin/io/polyakov/tracy/matcher/AnyCompositeCheckpointMatcherTest.kt
+++ b/common/src/test/kotlin/io/polyakov/tracy/matcher/AnyCompositeCheckpointMatcherTest.kt
@@ -6,17 +6,15 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.polyakov.tracy.model.TestCheckpoint
 
-class AllCompositeCheckpointMatcherTest : BehaviorSpec({
-    Given("AllCompositeCheckpointMatcher with by name and by class matcher") {
+class AnyCompositeCheckpointMatcherTest : BehaviorSpec({
+    Given("AnyCompositeCheckpointMatcher with two matchers for different names") {
         val checkpointName = "test-name"
-        val originalCheckpoint = TestCheckpoint(checkpointName)
-        val matcher = AllCompositeCheckpointMatcher(
+        val matcher = AnyCompositeCheckpointMatcher(
             NameCheckpointMatcher(checkpointName),
-            CheckpointMatcher { it is TestCheckpoint }, // by class matcher
-            CheckpointMatcher { it === originalCheckpoint } // by reference matcher
+            NameCheckpointMatcher("non-relevant-name")
         )
-        When("the same checkpoint is arrived") {
-            val result = matcher.matches(originalCheckpoint)
+        When("checkpoint with valid name is arrived") {
+            val result = matcher.matches(TestCheckpoint(checkpointName))
 
             Then("checkpoint matches") {
                 result.shouldBeTrue()
@@ -24,18 +22,17 @@ class AllCompositeCheckpointMatcherTest : BehaviorSpec({
         }
 
         When("another checkpoint is arrived") {
-            val result = matcher.matches(TestCheckpoint(checkpointName))
+            val result = matcher.matches(TestCheckpoint("completely-different-name"))
 
             Then("checkpoint doesn't match") {
                 result.shouldBeFalse()
             }
         }
     }
-
-    Given("AllCompositeCheckpointMatcher has no matchers") {
+    Given("AnyCompositeCheckpointMatcher has no matchers") {
         Then("instantiation failed with exception") {
             shouldThrow<IllegalArgumentException> {
-                AllCompositeCheckpointMatcher()
+                AnyCompositeCheckpointMatcher()
             }
         }
     }


### PR DESCRIPTION
It makes no sense to keep empty list of internal matchers for composite matchers, so throw an exception in this case.